### PR TITLE
Considere the ssh-authentication property

### DIFF
--- a/contents/ssh-copy.sh
+++ b/contents/ssh-copy.sh
@@ -46,7 +46,7 @@ SSHOPTS="-p -P $PORT -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 authentication=$RD_CONFIG_AUTHENTICATION
 
 
-if [[ "privatekey" == "$authentication" ]] ; then
+if [[ "privateKey" == "$authentication" ]] ; then
 
     #use ssh-keyfile node attribute from env vars
     if [[ -n "${RD_NODE_SSH_KEYFILE:-}" ]]

--- a/contents/ssh-exec.sh
+++ b/contents/ssh-exec.sh
@@ -41,7 +41,7 @@ SSHOPTS="-p $PORT -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o
 
 authentication=$RD_CONFIG_AUTHENTICATION
 
-if [[ "privatekey" == "$authentication" ]] ; then
+if [[ "privateKey" == "$authentication" ]] ; then
 
     #use ssh-keyfile node attribute from env vars
     if [[ -n "${RD_NODE_SSH_KEYFILE:-}" ]]


### PR DESCRIPTION
Hi,

The ssh-authentication property is not process correctly in the files ssh-copy.sh and ssh-exec.sh.
String "privatekey" vs "privateKey".

With this update, [this issue](https://github.com/rundeck/rundeck/issues/4561) works.

Example node configuration : 
```
  username: rundeck
  node-executor: ssh-exec
  file-copier: ssh-copier
  ssh-authentication: privateKey
  ssh-keyfile: /var/lib/rundeck/.ssh/id_rsa
```

If ssh-authentication: is set to "privatekey" (k lower case), Rundeck set the default value : "password".

Rémy