### PR TITLE
Fix some passphrase errors in exec and copy

### DIFF
--- a/contents/ssh-copy.sh
+++ b/contents/ssh-copy.sh
@@ -88,9 +88,9 @@ if [[ "privatekey" == "$authentication" ]] ; then
     if [[ -n "${!rd_secure_passphrase}" ]]; then
         mkdir -p "/tmp/.ssh-exec"
         SSH_KEY_PASSPHRASE_STORAGE_PATH=$(mktemp "/tmp/.ssh-exec/ssh-passfile.$USER@$HOST.XXXXX")
-        echo "${!rd_secure_passphrase}" > "$SSH_PASS_STORAGE_PATH"
+        echo "${!rd_secure_passphrase}" > "$SSH_KEY_PASSPHRASE_STORAGE_PATH"
 
-        RUNSSH="sshpass -P passphrase -f $SSH_KEY_PASSPHRASE_STORAGE_PATH ssh $SSHOPTS $USER@$HOST $CMD"
+        RUNSCP="sshpass -P passphrase -f $SSH_KEY_PASSPHRASE_STORAGE_PATH scp $SSHOPTS $FILE $USER@$HOST:$DIR"
 
         trap 'rm "$SSH_KEY_PASSPHRASE_STORAGE_PATH"' EXIT
     fi

--- a/contents/ssh-exec.sh
+++ b/contents/ssh-exec.sh
@@ -87,7 +87,7 @@ if [[ "privatekey" == "$authentication" ]] ; then
     if [[ -n "${!rd_secure_passphrase}" ]]; then
         mkdir -p "/tmp/.ssh-exec"
         SSH_KEY_PASSPHRASE_STORAGE_PATH=$(mktemp "/tmp/.ssh-exec/ssh-passfile.$USER@$HOST.XXXXX")
-        echo "${!rd_secure_passphrase}" > "$SSH_PASS_STORAGE_PATH"
+        echo "${!rd_secure_passphrase}" > "$SSH_KEY_PASSPHRASE_STORAGE_PATH"
 
         RUNSSH="sshpass -P passphrase -f $SSH_KEY_PASSPHRASE_STORAGE_PATH ssh $SSHOPTS $USER@$HOST $CMD"
 


### PR DESCRIPTION
This error is raised when I try to use passphrase option
`/var/lib/rundeck/libext/cache/openssh-node-execution-2.0.0/ssh-exec.sh: line 90: : No such file or directory`

https://github.com/rundeck-plugins/openssh-node-execution/blob/3aca64c0c6c71bae389cd2315542b0f428d4daa7/contents/ssh-exec.sh#L89-L90

Variable created in L89 is not used in L90. Instead a copy/pasted variable (`$SSH_PASS_STORAGE_PATH`) is used in L90


