### PR TITLE
Add ssh-agent startup when privkey is used

### DIFF
--- a/contents/ssh-exec.sh
+++ b/contents/ssh-exec.sh
@@ -87,6 +87,18 @@ if [[ "privatekey" == "$authentication" ]] ; then
         trap 'rm "$SSH_KEY_STORAGE_PATH"' EXIT
 
     fi
+
+    if [[ "$RD_CONFIG_FORWARD_AGENT" == "true" ]] ; then
+        # Start ssh-agent
+        eval `/usr/bin/ssh-agent`
+
+        # Add our ssh key to the agent
+        ssh-add $SSH_KEY_STORAGE_PATH
+
+        # kill ssh-agent once the job is over
+        trap '/usr/bin/ssh-agent -k' EXIT
+    fi
+
     RUNSSH="ssh $SSHOPTS $USER@$HOST $CMD"
 
     if [[ -n "${!rd_secure_passphrase}" ]]; then

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -27,6 +27,11 @@ providers:
           type: Boolean
           required: false
           description: 'Just echo what would be done'
+        - name: forward_agent
+          title: 'Forward SSH agent?'
+          type: Boolean
+          required: false
+          description: 'Start ssh-agent and forward keys'
         - type: Select
           name: authentication
           title: Authentication


### PR DESCRIPTION
This change will:
  - start ssh-agent when privkey auth is used
  - add the key to ssh-agent
  - cleanup the agent once the job is over

Useful for scenarios where Rundeck executes a job where further SSH
authentication/connection is required (example: rsync).