### PR TITLE
RUN-839: Fix: rd_secure_passphrase: invalid indirect expansion

### DIFF
--- a/contents/ssh-exec.sh
+++ b/contents/ssh-exec.sh
@@ -89,7 +89,7 @@ if [[ "privatekey" == "$authentication" ]] ; then
     fi
     RUNSSH="ssh $SSHOPTS $USER@$HOST $CMD"
 
-    if [[ -n "${!rd_secure_passphrase}" ]]; then
+    if [[ -n $rd_secure_passphrase ]] && [[ -n "${!rd_secure_passphrase}" ]]; then
         mkdir -p "/tmp/.ssh-exec"
         SSH_KEY_PASSPHRASE_STORAGE_PATH=$(mktemp "/tmp/.ssh-exec/ssh-passfile.$USER@$HOST.XXXXX")
         echo "${!rd_secure_passphrase}" > "$SSH_KEY_PASSPHRASE_STORAGE_PATH"
@@ -117,7 +117,7 @@ if [[ "password" == "$authentication" ]] ; then
     mkdir -p "/tmp/.ssh-exec"
     SSH_PASS_STORAGE_PATH=$(mktemp "/tmp/.ssh-exec/ssh-passfile.$USER@$HOST.XXXXX")
 
-    if [[ -n "${!rd_secure_password}" ]]; then
+    if [[ -n $rd_secure_password ]] && [[ -n "${!rd_secure_password}" ]]; then
         echo "${!rd_secure_password}" > "$SSH_PASS_STORAGE_PATH"
     else
         echo "$RD_CONFIG_SSH_PASSWORD_STORAGE_PATH" > "$SSH_PASS_STORAGE_PATH"


### PR DESCRIPTION
It was trying to do an indirect expansion on an undefined variable

Fix: https://github.com/rundeckpro/rundeckpro/issues/1906
Fix: https://github.com/rundeck-plugins/openssh-node-execution/issues/21