### PR TITLE
RSE-261 Fix: OpenSSH CopyFile not working on Docker

### DIFF
--- a/contents/ssh-copy.sh
+++ b/contents/ssh-copy.sh
@@ -117,8 +117,8 @@ if [[ "password" == "$authentication" ]] ; then
     mkdir -p "/tmp/.ssh-exec"
     SSH_PASS_STORAGE_PATH=$(mktemp "/tmp/.ssh-exec/ssh-passfile.$USER@$HOST.XXXXX")
 
-    if [[ -n "${!rd_secure_password}" ]]; then
-        echo "${!rd_secure_password}" > "$SSH_PASS_STORAGE_PATH"
+    if [[ -n "${rd_secure_password}" ]]; then
+        echo "${rd_secure_password}" > "$SSH_PASS_STORAGE_PATH"
     else
         echo "$RD_CONFIG_SSH_PASSWORD_STORAGE_PATH" > "$SSH_PASS_STORAGE_PATH"
     fi


### PR DESCRIPTION
## Overview
When the "copy file" step was invoked, the script inside the node executor throw an error stating: "invalid indirect expansion"

## The Problem
The script was wrongly evaluating the variable "rd_secure_password", putting "!" char before a variable means "a variable that matches with" not a negation of a expression.

See [this](https://stackoverflow.com/questions/8515411/what-is-indirect-expansion-what-does-var-mean) for more info.

## The Fix
Removing the previously mentioned char.
